### PR TITLE
Update dependencies

### DIFF
--- a/numerai_tools/scoring.py
+++ b/numerai_tools/scoring.py
@@ -308,7 +308,7 @@ def one_hot_encode(
         one_hot = encoder.fit_transform(df[[col]])
         one_hot = pd.DataFrame(
             one_hot.toarray(),
-            columns=encoder.get_feature_names(),
+            columns=encoder.get_feature_names_out(),
             index=df.index,
         )
         df = df.join(one_hot).drop(columns=col)

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ if __name__ == "__main__":
         package_data={"numerai": ["LICENSE", "README.md"]},
         packages=find_packages(exclude=["tests"]),
         install_requires=[
-            "pandas<=2.1.3",
-            "numpy<=1.26.2",
-            "scipy<=1.11.4",
-            "scikit-learn<=1.3.2",
+            "pandas>=1.3.1, <=2.1.3",
+            "numpy~=1.26.2",
+            "scipy~=1.11.4",
+            "scikit-learn>=1.3.0, <=1.3.2",
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-VERSION = "0.0.13"
+VERSION = "0.0.14"
 
 
 def load(path):
@@ -37,9 +37,9 @@ if __name__ == "__main__":
         package_data={"numerai": ["LICENSE", "README.md"]},
         packages=find_packages(exclude=["tests"]),
         install_requires=[
-            "pandas~=1.3.1",
-            "numpy~=1.21.6",
-            "scipy~=1.2.1",
-            "scikit-learn~=1.0",
+            "pandas<=2.1.3",
+            "numpy<=1.26.2",
+            "scipy<=1.11.4",
+            "scikit-learn<=1.3.2",
         ],
     )


### PR DESCRIPTION
1. Update dependencies to more recent versions. 
2. `OneHotEncoder` now uses the modern `get_feature_names_out()` (scikit-learn 1.3+) instead of `get_feature_names()`.

All tests pass locally with newest `numpy`, `scipy`, `pandas` and `scikit-learn` releases. 

Would also be happy to help with setting up [Poetry](https://python-poetry.org) for `numerai-tools` if you are open to it. Would make project/dependency management, releasing on PyPi, etc. more convenient.

Addressed in PR #12 