### PR TITLE
add top_bottom filter to numerai_corr, add np.abs to max_feature_correlation

### DIFF
--- a/numerai_tools/scoring.py
+++ b/numerai_tools/scoring.py
@@ -427,8 +427,9 @@ def max_feature_correlation(
                             and the correlation with that feature
     """
     feature_correlations = features.apply(
-        lambda f: np.abs(pearson_correlation(f, s, top_bottom))
+        lambda f: pearson_correlation(f, s, top_bottom)
     )
+    feature_correlations = np.abs(feature_correlations)
     max_feature = feature_correlations.idxmax()
     max_corr = feature_correlations[max_feature]
     return max_feature, max_corr

--- a/numerai_tools/scoring.py
+++ b/numerai_tools/scoring.py
@@ -369,9 +369,15 @@ def numerai_corr(
         pd.Series - the resulting correlation scores for each column in predictions
     """
     targets -= targets.mean()
-    targets, predictions = filter_sort_index(
-        targets, predictions, max_filtered_index_ratio
-    )
+    if top_bottom is not None and top_bottom > 0:
+        predictions = filter_top_bottom(predictions, top_bottom)
+        targets, predictions = filter_sort_index(
+            targets, predictions, (1 - top_bottom / len(targets))
+        )
+    else:
+        targets, predictions = filter_sort_index(
+            targets, predictions, max_filtered_index_ratio
+        )
     predictions = tie_kept_rank__gaussianize__pow_1_5(predictions)
     targets = power(targets.to_frame(), 1.5)[targets.name]
     scores = predictions.apply(lambda sub: pearson_correlation(targets, sub))
@@ -421,7 +427,7 @@ def max_feature_correlation(
                             and the correlation with that feature
     """
     feature_correlations = features.apply(
-        lambda f: pearson_correlation(f, s, top_bottom)
+        lambda f: np.abs(pearson_correlation(f, s, top_bottom))
     )
     max_feature = feature_correlations.idxmax()
     max_corr = feature_correlations[max_feature]


### PR DESCRIPTION
two user reported issues:

* the top_bottom arg in numerai_corr doesn't do anything. 
  * I wasn't 100% sure about whether or not it should happen before the `tie_kept_rank__gaussianize__pow_1_5` step, but followed the same convention from signals diagnostics.
* the max_feature_correlation feature should have an `abs` because of negative correlations

These changes are not tested yet. @ndharasz lmk if this looks good, and if you aren't able to test I can do it and get this merged