### PR TITLE
Relax scikit-learn version to accommodate version 1.4+

### DIFF
--- a/numerai_tools/scoring.py
+++ b/numerai_tools/scoring.py
@@ -308,7 +308,7 @@ def one_hot_encode(
         one_hot = encoder.fit_transform(df[[col]])
         one_hot = pd.DataFrame(
             one_hot.toarray(),
-            columns=encoder.get_feature_names(),
+            columns=encoder.get_feature_names_out(),
             index=df.index,
         )
         df = df.join(one_hot).drop(columns=col)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ if __name__ == "__main__":
             "pandas>=1.3.1, <=2.1.3",
             "numpy~=1.26.2",
             "scipy~=1.11.4",
-            "scikit-learn>=1.3.0, <=1.3.2",
+            "scikit-learn>=1.3.0",
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ if __name__ == "__main__":
         package_data={"numerai": ["LICENSE", "README.md"]},
         packages=find_packages(exclude=["tests"]),
         install_requires=[
-            "pandas<=2.1.3",
-            "numpy<=1.26.2",
-            "scipy<=1.11.4",
-            "scikit-learn<=1.3.2",
+            "pandas>=1.3.1, <=2.1.3",
+            "numpy~=1.26.2",
+            "scipy~=1.11.4",
+            "scikit-learn>=1.3.0, <=1.3.2",
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-VERSION = "0.0.13"
+VERSION = "0.0.14"
 
 
 def load(path):
@@ -37,9 +37,9 @@ if __name__ == "__main__":
         package_data={"numerai": ["LICENSE", "README.md"]},
         packages=find_packages(exclude=["tests"]),
         install_requires=[
-            "pandas~=1.3.1",
-            "numpy~=1.21.6",
-            "scipy~=1.2.1",
-            "scikit-learn~=1.0",
+            "pandas<=2.1.3",
+            "numpy<=1.26.2",
+            "scipy<=1.11.4",
+            "scikit-learn<=1.3.2",
         ],
     )


### PR DESCRIPTION
A few weeks ago scikit-learn 1.4 was released. This changes the scikit-learn version constraint in `setup.py` so it can be used with [scikit-learn 1.4+](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_4_0.html). 

Tests are passing with scikit-learn 1.4.0. 👍