### PR TITLE
Speed up numerai_corr x 2

### DIFF
--- a/numerai_tools/scoring.py
+++ b/numerai_tools/scoring.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 from sklearn.preprocessing import OneHotEncoder
-import time
 
 # sometimes when we match up the target/prediction indices,
 # changes in stock universe causes some stocks to enter / leave,
@@ -430,7 +429,6 @@ def numerai_corr(
     Returns:
         pd.Series - the resulting correlation scores for each column in predictions
     """
-
     targets = targets - targets.mean()
     targets, predictions = filter_sort_index(
         targets, predictions, max_filtered_index_ratio


### PR DESCRIPTION
This PR introduces a benchmark for the power function and numerai_corr, running each function 1000 times to measure performance. Additionally, a significant speedup was achieved by optimizing a slow assertion in the power function, replacing the power function it with a more efficient numpy based implementation.

The results of the speedup are: 

Master:
Execution time power_bench: 3.6272 seconds
Execution time numerai_corr_bench: 10.5109 seconds

This branch:
Execution time power_bench: 0.7179 seconds
Execution time numerai_corr_bench: 4.9527 seconds



To run the benchmark do: 
python -m  tests.test_scoring
Additionally, it can be run with --profile argument to do profiling of the functions.