### PR TITLE
0.2.4 - remove CUSIP & lock numpy

### DIFF
--- a/numerai_tools/submissions.py
+++ b/numerai_tools/submissions.py
@@ -10,7 +10,6 @@ NUMERAI_ALLOWED_PRED_COLS = ["prediction", "probability"]
 
 SIGNALS_ALLOWED_ID_COLS = [
     "ticker",
-    "cusip",
     "sedol",
     "bloomberg_ticker",
     "composite_figi",
@@ -117,9 +116,6 @@ def _validate_ids(
 
     index_sub = submission.copy()
     index_sub[id_col] = index_sub[id_col].astype(str)
-    if id_col == "cusip":
-        # normalize cusip tickers to 9 digits
-        index_sub[id_col] = index_sub[id_col].apply(lambda x: x.zfill(9))
 
     live_ids = live_ids.astype(str)
     live_sub = index_sub[index_sub[id_col].isin(live_ids)].sort_values(id_col)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-VERSION = "0.2.3"
+VERSION = "0.2.4"
 
 
 def load(path):
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=["tests"]),
         install_requires=[
             "pandas>=1.3.1",
-            "numpy>=1.26.2",
+            "numpy>=1.26.4,<2.0.0",
             "scipy>=1.11.4",
             "scikit-learn>=1.3.0",
         ],

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -265,24 +265,6 @@ class TestSubmissions(unittest.TestCase):
             len(self.ids),
         )
 
-    def test_validate_ids_cusip(self):
-        # check that cusips are zfilled
-        cusip_sub = generate_submission(self.ids, "cusip", "prediction")
-        cusip_sub.loc[0, "cusip"] = cusip_sub.loc[0]["cusip"][1:]
-        cusip_ids = self.ids.copy()
-        cusip_ids.loc[0] = "0" + cusip_ids[0][1:]
-        new_sub, invalid_ids = _validate_ids(
-            cusip_ids, cusip_sub, "cusip", len(self.ids)
-        )
-        assert (
-            (
-                new_sub["prediction"].sort_values()
-                == cusip_sub["prediction"].sort_values()
-            )
-            .all()
-            .all()
-        )
-
     def test_validate_ids_duplicates(self):
         dup_sub = generate_submission(self.ids, "id", "prediction")
         dup_sub.loc[0] = dup_sub.loc[1]


### PR DESCRIPTION
- eliminate references to CUSIP
- force numpy < 2.0 to eliminate dtype compatibility error (see https://github.com/numpy/numpy/issues/26710)